### PR TITLE
style: add line clamp to article in article search list page

### DIFF
--- a/src/app/ArticleSearchList.tsx
+++ b/src/app/ArticleSearchList.tsx
@@ -86,7 +86,7 @@ const ArticleList: React.FC<{
                   <div>
                     <h3 className='font-sans font-bold text-lg text-primary'>{title}</h3>
 
-                    <p className='font-serif text-primary'>{description}</p>
+                    <p className='font-serif text-primary line-clamp-3'>{description}</p>
 
                     <div className='font-mono text-sm font-thin text-primary'>
                       <span>{formatDistanceToNow(new Date(savedAt))}</span>


### PR DESCRIPTION
Adds line clamp to article's description in article search list page instead of rendering the whole article in description.
Fix for #15 